### PR TITLE
Master+debian bullseye

### DIFF
--- a/99-openroast.rules
+++ b/99-openroast.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5523", MODE="0666"

--- a/build-app-requirements.txt
+++ b/build-app-requirements.txt
@@ -1,3 +1,3 @@
-PyQt5>=5.8,<5.9
+PyQt5>=5.8,<5.15
 matplotlib>=2.0,<2.1
 freshroastsr700>=0.2.3

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['PyQt5>=5.8,<5.9',
+    install_requires=['PyQt5>=5.8,<5.15',
                       'matplotlib>=2.0,<2.1',
                       'freshroastsr700>=0.2.1'],
 


### PR DESCRIPTION
This pull request fixes several issues I had running the application out-of-box on Debian Bullseye on an old Pentium M laptop I have.

1. Simple QT versioning bump to 15
2. Fixing and documenting udev rules for the serial port.

Once done and updated the application runs on Bullseye and my SR700 roasts away happy as larry.