### PR TITLE
Fix two undefined names and two typos

### DIFF
--- a/openroast/views/customqtwidgets.py
+++ b/openroast/views/customqtwidgets.py
@@ -189,7 +189,7 @@ class LogModel(QtWidgets.QFileSystemModel):
 
     def data(self, index, role):
         if index.column() == self.columnCount() - 1:
-            if role == Qt.DisplayRole:
+            if role == QtCore.Qt.DisplayRole:
                 filePath = self.filePath(index)
                 if os.path.isfile(filePath):
                     with open(filePath) as json_data:

--- a/openroast/views/recipeeditorwindow.py
+++ b/openroast/views/recipeeditorwindow.py
@@ -355,7 +355,7 @@ class RecipeEditor(QtWidgets.QDialog):
         self.rebuild_recipe_steps_table(newSteps)
 
     def insert_recipe_step(self, row):
-        """Inserts a row below the specified row wit generic values."""
+        """Inserts a row below the specified row with generic values."""
         steps = self.get_current_table_values()
         newSteps = steps
 
@@ -393,7 +393,7 @@ class RecipeEditor(QtWidgets.QDialog):
             alert = QtWidgets.QMessageBox()
             alert.setWindowTitle('openroast')
             alert.setStyleSheet(self.style)
-            alert.setText("You must have atleast one step!")
+            alert.setText("You must have at least one step!")
             alert.exec_()
 
         else:

--- a/openroast/views/recipeeditorwindow.py
+++ b/openroast/views/recipeeditorwindow.py
@@ -4,6 +4,7 @@
 import os
 import json
 import time
+import errno
 import functools
 
 from PyQt5 import QtGui


### PR DESCRIPTION
Fix two undefined names discovered by flake8 and two typos discovered by codespell in #86.
1. Fix undefined name: import errno for line 443 — https://docs.python.org/3/library/errno.html
2. Fix undefined name: Qt to match line 168
3. Fix two typos discovered by codespell